### PR TITLE
fix: 🐛 held lock is 'shared', request lock ifAvailable is true

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -235,7 +235,14 @@ export class WebLocks {
           return e.name === name;
         });
       } else if (_options.ifAvailable) {
-        if (heldLock || requestLockQueue.length) {
+        if (
+          (heldLock &&
+            !(
+              heldLock.mode === LOCK_MODE.SHARED &&
+              _options.mode === LOCK_MODE.SHARED
+            )) ||
+          requestLockQueue.length
+        ) {
           try {
             const result = await cb(null);
             return resolve(result);


### PR DESCRIPTION
when held lock's mode is 'shared' and the request lock's mode is
'shared' and ifAvailable option is true, this request could be granted
this lock