### PR TITLE
fix: 🐛  Fix release on exception

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -421,6 +421,7 @@ export class LockManager {
             _resolve(res);
             resolve(res);
           } catch (error) {
+            _resolve(error);
             reject(error);
           }
         });

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -131,7 +131,7 @@ export class LockManager {
         reject,
       };
 
-      const resolveWithCB = self._resolveWithCB(request, cb, resolve, reject);
+      const resolveWithCB = self._resolveWithCB(cb, resolve, reject);
 
       let heldLockSet = self._heldLockSet();
       let heldLock = heldLockSet.find((e) => {
@@ -404,7 +404,6 @@ export class LockManager {
 
   // let cb executed in Micro task
   private _resolveWithCB(
-    request: Request,
     cb: LockGrantedCallback,
     resolve: (value?: unknown) => void,
     reject: (reason?: any) => void

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -43,8 +43,6 @@ export type LockInfo = Lock & {
 type Request = LockInfo & {
   resolve: (value?: unknown) => void;
   reject: (reason?: any) => void;
-  cbResolve?: (value?: unknown) => void;
-  cbReject?: (reason?: any) => void;
 };
 
 type RequestArgsCase1 = [name: string, callback: LockGrantedCallback];
@@ -412,9 +410,7 @@ export class LockManager {
     reject: (reason?: any) => void
   ) {
     return (args: Lock | null) => {
-      return new Promise((_resolve, _reject) => {
-        request.cbResolve = _resolve;
-        request.cbReject = _reject;
+      return new Promise((_resolve) => {
         new Promise((res) => res("")).then(async () => {
           try {
             const res = await cb(args);

--- a/test/acquire.test.ts
+++ b/test/acquire.test.ts
@@ -11,10 +11,11 @@ async function testCallBackArg(arg: any) {
     // @ts-ignore
     await webLocks.request(sourceName, arg);
   } catch (error) {
-    expect(error.message).toEqual(
+    expect(error).toHaveProperty(
+      "message",
       "Failed to execute 'request' on 'LockManager': parameter 2 is not of type 'Function'."
     );
-    expect(error.name).toEqual("TypeError");
+    expect(error).toHaveProperty("name", "TypeError");
   }
 }
 
@@ -100,7 +101,8 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
         (lock) => {}
       );
     } catch (error) {
-      expect(error.message).toEqual(
+      expect(error).toHaveProperty(
+        "message",
         "Failed to execute 'request' on 'LockManager': The 'steal' and 'ifAvailable' options cannot be used together."
       );
       expect(error instanceof DOMException).toBeTruthy();
@@ -119,7 +121,8 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
         (lock) => {}
       );
     } catch (error) {
-      expect(error.message).toEqual(
+      expect(error).toHaveProperty(
+        "message",
         "Failed to execute 'request' on 'LockManager': The 'steal' option may only be used with 'exclusive' locks."
       );
       expect(error instanceof DOMException).toBeTruthy();
@@ -139,7 +142,8 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
         (lock) => {}
       );
     } catch (error) {
-      expect(error.message).toEqual(
+      expect(error).toHaveProperty(
+        "message",
         "Failed to execute 'request' on 'LockManager': The 'signal' and 'steal' options cannot be used together."
       );
       expect(error instanceof DOMException).toBeTruthy();
@@ -159,7 +163,8 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
         (lock) => {}
       );
     } catch (error) {
-      expect(error.message).toEqual(
+      expect(error).toHaveProperty(
+        "message",
         "Failed to execute 'request' on 'LockManager': The 'signal' and 'ifAvailable' options cannot be used together."
       );
       expect(error instanceof DOMException).toBeTruthy();

--- a/test/acquire.test.ts
+++ b/test/acquire.test.ts
@@ -227,6 +227,9 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
     } catch (error) {
       expect(error).toEqual(test_error);
     }
+
+    // this held lock should be released;
+    expect((await webLocks.query()).held).toHaveLength(0);
   });
 
   test("Returned Promise rejects if callback throws asynchronously", async () => {
@@ -245,5 +248,8 @@ describe("Returned Promise rejects if callback throws asynchronously", () => {
     } catch (error) {
       expect(error).toEqual(test_error);
     }
+
+    // this held lock should be released;
+    expect((await webLocks.query()).held).toHaveLength(0);
   });
 });

--- a/test/ifAvailable.test.ts
+++ b/test/ifAvailable.test.ts
@@ -318,6 +318,7 @@ describe("Web Locks API: ifAvailable option", () => {
 
         // at this point there should only be one lock held, namely sourceName1
         expect((await webLocks.query()).held).toHaveLength(1);
+        expect((await webLocks.query()).held[0].name).toEqual(sourceName1);
 
         expect(callback2_called).toBeTruthy();
       }

--- a/test/resource-names.test.ts
+++ b/test/resource-names.test.ts
@@ -53,7 +53,8 @@ describe("Web Locks API: Resources DOMString edge cases", () => {
         //Names starting with "-" should be rejected
         await webLocks.request(name, (lock) => {});
       } catch (error) {
-        expect(error.message).toEqual(
+        expect(error).toHaveProperty(
+          "message",
           "Failed to execute 'request' on 'LockManager': Names cannot start with '-'."
         );
         expect(error instanceof DOMException).toBeTruthy();

--- a/test/signal.test.ts
+++ b/test/signal.test.ts
@@ -40,8 +40,9 @@ describe("Web Locks API: AbortSignal integration", () => {
         expect(cb).not.toHaveBeenCalled();
       } catch (error) {
         // Bindings should throw if the signal option is a not an AbortSignal
-        expect(error.name).toEqual("TypeError");
-        expect(error.message).toEqual(
+        expect(error).toHaveProperty("name", "TypeError");
+        expect(error).toHaveProperty(
+          "message",
           "Failed to execute 'request' on 'LockManager': member signal is not of type AbortSignal."
         );
       }
@@ -63,7 +64,8 @@ describe("Web Locks API: AbortSignal integration", () => {
     } catch (error) {
       // Request should reject with AbortError
       expect(error instanceof DOMException).toBeTruthy();
-      expect(error.message).toEqual(
+      expect(error).toHaveProperty(
+        "message",
         "Failed to execute 'request' on 'LockManager': The request was aborted."
       );
     }


### PR DESCRIPTION
I found a bug where the lock is not released if the user-provided callback raises an exception. This adds a test which shows the bug and adds a fix for the bug. There is also one extra commit to make the tests run on newer versions of typescript and one commit that removes some confusing code that is not used.