### PR TITLE
chore(tests): Cleaner test setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "navigator.locks",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "navigator.locks",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup/afterEnv.ts"
+    ]
   },
   "engines": {
     "node": ">=20.x <=24.x"

--- a/test/acquire.test.ts
+++ b/test/acquire.test.ts
@@ -1,5 +1,4 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
 } from "./helpers";
@@ -20,8 +19,6 @@ async function testCallBackArg(arg: any) {
 }
 
 describe("Returned Promise rejects if callback throws asynchronously", () => {
-  beforeEachHandle();
-
   test("navigator.locks.request requires a name and a callback", async () => {
     const webLocks = createWebLocksInstance();
     try {

--- a/test/held.test.ts
+++ b/test/held.test.ts
@@ -1,13 +1,10 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
   sleep,
 } from "./helpers";
 
 describe("Web Locks API: Lock held until callback result resolves", () => {
-  beforeEachHandle();
-
   test("callback's result is promisified if not async", async () => {
     const webLocks = createWebLocksInstance();
     const sourceName = generateRandomId();

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,17 +2,6 @@ import { LockManager } from "../src/polyfill";
 export * from "../src/sleep";
 export * from "../src/polyfill";
 
-let mockFridge: { [P: string]: any } = {};
-
-export function beforeEachHandle() {
-  beforeEach(() => {
-    global.Storage.prototype.setItem = jest.fn((key, value) => {
-      mockFridge[key] = value;
-    });
-    global.Storage.prototype.getItem = jest.fn((key) => mockFridge[key]);
-  });
-}
-
 export function createWebLocksInstance() {
   const webLocks = new LockManager();
   window.localStorage.removeItem("heldLockSet");

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -3,9 +3,8 @@ export * from "../src/sleep";
 export * from "../src/polyfill";
 
 export function createWebLocksInstance() {
-  const webLocks = new LockManager();
-  window.localStorage.removeItem("heldLockSet");
-  return webLocks;
+  localStorage.clear();
+  return new LockManager();
 }
 
 export const neverSettledPromise = new Promise((resolve) => {

--- a/test/ifAvailable.test.ts
+++ b/test/ifAvailable.test.ts
@@ -1,13 +1,10 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
   sleep,
 } from "./helpers";
 
 describe("Web Locks API: ifAvailable option", () => {
-  beforeEachHandle();
-
   test("Lock request with ifAvailable - lock available", async () => {
     const webLocks = createWebLocksInstance();
     const sourceName = generateRandomId();

--- a/test/lock-attributes.test.ts
+++ b/test/lock-attributes.test.ts
@@ -1,8 +1,6 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 describe("Web Locks API: Lock Attributes", () => {
-  beforeEachHandle();
-
   test("Lock attributes reflect requested properties (exclusive)", async () => {
     const webLocks = createWebLocksInstance();
 

--- a/test/mode-exclusive.test.ts
+++ b/test/mode-exclusive.test.ts
@@ -1,8 +1,6 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 describe("test suite of Web Locks API: mode-exclusive", () => {
-  beforeEachHandle();
-
   test("Lock requests are granted in order", async () => {
     const granted: Number[] = [];
     function log_grant(n: number) {

--- a/test/mode-mixed.test.ts
+++ b/test/mode-mixed.test.ts
@@ -1,8 +1,6 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 describe("Web Locks API: Mixed Modes", () => {
-  beforeEachHandle();
-
   test("Lock requests are granted in order", async () => {
     const webLocks = createWebLocksInstance();
 

--- a/test/mode-shared.test.ts
+++ b/test/mode-shared.test.ts
@@ -1,8 +1,6 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 describe("Web Locks API: mode-shared", () => {
-  beforeEachHandle();
-
   test("Lock requests are granted in order", async () => {
     const granted: Number[] = [];
     function log_grant(n: number) {

--- a/test/query-empty.test.ts
+++ b/test/query-empty.test.ts
@@ -1,8 +1,6 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 describe("Web Locks API: navigator.locks.query method - no locks held", () => {
-  beforeEachHandle();
-
   test("query() returns dictionary with empty arrays when no locks are held", async () => {
     const webLocks = createWebLocksInstance();
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,5 +1,4 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
   LockInfo,
@@ -15,8 +14,6 @@ function clients(list: LockInfo[], name: string) {
 }
 
 describe("Web Locks API: navigator.locks.query method", () => {
-  beforeEachHandle();
-
   test("query() returns dictionaries with expected properties", async () => {
     const webLocks = createWebLocksInstance();
     const sourceName = generateRandomId();

--- a/test/resource-names.test.ts
+++ b/test/resource-names.test.ts
@@ -1,4 +1,4 @@
-import { beforeEachHandle, createWebLocksInstance } from "./helpers";
+import { createWebLocksInstance } from "./helpers";
 
 function code_points(s: string) {
   return [...s]
@@ -7,8 +7,6 @@ function code_points(s: string) {
 }
 
 describe("Web Locks API: Resources DOMString edge cases", () => {
-  beforeEachHandle();
-
   [
     "", // Empty strings
     "abc\x00def", // Embedded NUL

--- a/test/setup/afterEnv.ts
+++ b/test/setup/afterEnv.ts
@@ -1,0 +1,9 @@
+const mockFridge: { [P: string]: any } = {};
+
+beforeEach(() => {
+  global.Storage.prototype.setItem = jest.fn((key, value) => {
+    mockFridge[key] = value;
+  });
+
+  global.Storage.prototype.getItem = jest.fn((key) => mockFridge[key]);
+});

--- a/test/setup/afterEnv.ts
+++ b/test/setup/afterEnv.ts
@@ -1,9 +1,9 @@
 const mockFridge: { [P: string]: any } = {};
 
 beforeEach(() => {
-  global.Storage.prototype.setItem = jest.fn((key, value) => {
+  Storage.prototype.setItem = jest.fn((key, value) => {
     mockFridge[key] = value;
   });
 
-  global.Storage.prototype.getItem = jest.fn((key) => mockFridge[key]);
+  Storage.prototype.getItem = jest.fn((key) => mockFridge[key]);
 });

--- a/test/signal.test.ts
+++ b/test/signal.test.ts
@@ -1,5 +1,4 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
 } from "./helpers";
@@ -13,8 +12,6 @@ function makePromiseAndResolveFunc(): any[] {
 }
 
 describe("Web Locks API: AbortSignal integration", () => {
-  beforeEachHandle();
-
   test("The signal option must be an AbortSignal", async () => {
     // These cases should not work:
     for (const signal of [

--- a/test/steal.test.ts
+++ b/test/steal.test.ts
@@ -1,13 +1,10 @@
 import {
-  beforeEachHandle,
   createWebLocksInstance,
   generateRandomId,
   neverSettledPromise,
 } from "./helpers";
 
 describe("Web Locks API: steal option", () => {
-  beforeEachHandle();
-
   test("Lock available", async () => {
     const webLocks = createWebLocksInstance();
     const sourceName = generateRandomId();


### PR DESCRIPTION
- Use jest's `setupFilesAfterEnv` for common before-hook instead of manually importing it everywhere
- Clear localStorage before creating lock manager (fixes flaky query.test.ts)