### PR TITLE
fix: 🐛 use pagehide for lifecycle cleanup

### DIFF
--- a/src/heartBeat.ts
+++ b/src/heartBeat.ts
@@ -17,8 +17,10 @@ export class HeartBeat {
     this._key = key;
     this._heartBeatIntervalTime = heartBeatIntervalTime;
     this._heartBeatDetectIntervalTime = heartBeatDetectIntervalTime;
-    window.addEventListener("unload", () => {
-      this.destroy();
+    window.addEventListener("pagehide", (event) => {
+      if (!event.persisted) {
+        this.destroy();
+      }
     });
   }
 

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -94,9 +94,9 @@ export class LockManager {
     this._storeThisClientId();
     const heartBeat = new HeartBeat({ key: this._clientId });
     heartBeat.start();
-    // handle when unload could't work or the client crash, then clean
+    // Clean stale clients if pagehide does not fire or a client crashes.
     heartBeat.detect(() => this._cleanUnliveClientLocks());
-    this._onUnload();
+    this._onPageHide();
   }
 
   private _getClientIds(): string[] {
@@ -602,9 +602,11 @@ export class LockManager {
     return queryResult;
   }
 
-  private _onUnload() {
-    window.addEventListener("unload", (e) => {
-      this._cleanClientLocksByClientId(this._clientId);
+  private _onPageHide() {
+    window.addEventListener("pagehide", (event) => {
+      if (!event.persisted) {
+        this._cleanClientLocksByClientId(this._clientId);
+      }
     });
   }
 

--- a/test/bfcache.test.ts
+++ b/test/bfcache.test.ts
@@ -1,0 +1,106 @@
+import { HeartBeat } from "../src/heartBeat";
+import {
+  createWebLocksInstance,
+  generateRandomId,
+  neverSettledPromise,
+} from "./helpers";
+
+function dispatchPageHide(persisted: boolean) {
+  const event = new Event("pagehide") as PageTransitionEvent;
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+}
+
+async function acquireHeldLock() {
+  const webLocks = createWebLocksInstance();
+  const sourceName = generateRandomId();
+  let granted: () => void = () => {};
+  const lockGrantedPromise = new Promise<void>((resolve) => {
+    granted = resolve;
+  });
+
+  webLocks
+    .request(sourceName, () => {
+      granted();
+      return neverSettledPromise;
+    })
+    .catch(() => undefined);
+  await lockGrantedPromise;
+
+  return webLocks;
+}
+
+describe("Web Locks API: BFCache lifecycle", () => {
+  afterEach(() => {
+    dispatchPageHide(false);
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test("uses pagehide instead of unload for lifecycle cleanup", () => {
+    const addEventListener = jest.spyOn(window, "addEventListener");
+
+    createWebLocksInstance();
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      "pagehide",
+      expect.any(Function)
+    );
+    expect(addEventListener).not.toHaveBeenCalledWith(
+      "unload",
+      expect.any(Function)
+    );
+  });
+
+  test("releases this client's held locks on non-BFCache pagehide", async () => {
+    const webLocks = await acquireHeldLock();
+
+    expect((await webLocks.query()).held).toHaveLength(1);
+
+    dispatchPageHide(false);
+
+    expect((await webLocks.query()).held).toHaveLength(0);
+  });
+
+  test("does not release this client's held locks when pagehide enters bfcache", async () => {
+    const webLocks = await acquireHeldLock();
+
+    dispatchPageHide(true);
+
+    expect((await webLocks.query()).held).toHaveLength(1);
+  });
+
+  test("does not destroy heartbeat when pagehide enters bfcache", () => {
+    jest.useFakeTimers();
+    const heartBeat = new HeartBeat({
+      key: "$navigator.locks-test-client",
+    });
+    heartBeat.start();
+
+    dispatchPageHide(true);
+    jest.advanceTimersByTime(1000);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "$navigator.locks-test-client",
+      expect.any(String)
+    );
+
+    heartBeat.destroy();
+  });
+
+  test("destroys heartbeat on non-BFCache pagehide", () => {
+    jest.useFakeTimers();
+    const heartBeat = new HeartBeat({
+      key: "$navigator.locks-test-client",
+    });
+    heartBeat.start();
+
+    dispatchPageHide(false);
+    jest.advanceTimersByTime(1000);
+
+    expect(localStorage.setItem).not.toHaveBeenCalledWith(
+      "$navigator.locks-test-client",
+      expect.any(String)
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #56 by replacing lifecycle cleanup that relied on the deprecated `unload` event with `pagehide`.

## Why

Registering `unload` handlers can trigger Chrome permissions policy warnings. Unlike `unload`, `pagehide` also reports whether a page is entering the back-forward cache through `event.persisted`.

## Changes

- Stop registering `unload` handlers for heartbeat and lock cleanup.
- Clean up heartbeat timers and this client's locks on non-BFCache `pagehide`.
- Preserve the current lifecycle state when `pagehide.persisted === true`.
- Add Jest regression coverage in `test/bfcache.test.ts` for both lifecycle branches.

The tests exercise this polyfill's lifecycle handling; existing cross-context heartbeat behavior is unchanged.

## Validation

- `npm test -- --runInBand` (13 suites, 68 tests)
- `npm run lint`
- `npm run build`
